### PR TITLE
fix: Add PDB and change replica policy to uat and prod

### DIFF
--- a/helm/prod/top/emd-ar-backoffice-bff/values.yaml
+++ b/helm/prod/top/emd-ar-backoffice-bff/values.yaml
@@ -22,3 +22,14 @@ microservice-chart:
     enable: true
     minReplica: 2
     maxReplica: 4
+    pollingInterval: 30 # seconds
+    cooldownPeriod: 300 # seconds
+    triggers:
+      - type: cpu
+        metadata:
+          type: Utilization
+          value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1

--- a/helm/prod/top/emd-citizen/values.yaml
+++ b/helm/prod/top/emd-citizen/values.yaml
@@ -17,8 +17,8 @@ microservice-chart:
 
   autoscaling:
     enable: true
-    minReplica: 1
-    maxReplica: 2
+    minReplica: 2
+    maxReplica: 4
     pollingInterval: 30 # seconds
     cooldownPeriod: 300 # seconds
     triggers:
@@ -26,6 +26,10 @@ microservice-chart:
         metadata:
           type: Utilization
           value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
 
   envConfig:
     MONGODB_DBNAME: mdc

--- a/helm/prod/top/emd-message-core/values.yaml
+++ b/helm/prod/top/emd-message-core/values.yaml
@@ -17,8 +17,8 @@ microservice-chart:
 
   autoscaling:
     enable: true
-    minReplica: 1
-    maxReplica: 2
+    minReplica: 2
+    maxReplica: 4
     pollingInterval: 30 # seconds
     cooldownPeriod: 300 # seconds
     triggers:
@@ -26,6 +26,10 @@ microservice-chart:
         metadata:
           type: Utilization
           value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
 
   envConfig:
     MONGODB_DBNAME: mdc

--- a/helm/prod/top/emd-notifier-sender/values.yaml
+++ b/helm/prod/top/emd-notifier-sender/values.yaml
@@ -17,8 +17,8 @@ microservice-chart:
 
   autoscaling:
     enable: true
-    minReplica: 1
-    maxReplica: 2
+    minReplica: 2
+    maxReplica: 4
     pollingInterval: 30 # seconds
     cooldownPeriod: 300 # seconds
     triggers:
@@ -26,6 +26,10 @@ microservice-chart:
         metadata:
           type: Utilization
           value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
 
   envConfig:
     MONGODB_DBNAME: mdc

--- a/helm/prod/top/emd-payment-core/values.yaml
+++ b/helm/prod/top/emd-payment-core/values.yaml
@@ -17,8 +17,8 @@ microservice-chart:
 
   autoscaling:
     enable: true
-    minReplica: 1
-    maxReplica: 2
+    minReplica: 2
+    maxReplica: 4
     pollingInterval: 30 # seconds
     cooldownPeriod: 300 # seconds
     triggers:
@@ -26,6 +26,10 @@ microservice-chart:
         metadata:
           type: Utilization
           value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
 
   envConfig:
     MONGODB_DBNAME: mdc

--- a/helm/prod/top/emd-tpp/values.yaml
+++ b/helm/prod/top/emd-tpp/values.yaml
@@ -17,8 +17,8 @@ microservice-chart:
 
   autoscaling:
     enable: true
-    minReplica: 1
-    maxReplica: 2
+    minReplica: 2
+    maxReplica: 4
     pollingInterval: 30 # seconds
     cooldownPeriod: 300 # seconds
     triggers:
@@ -26,6 +26,10 @@ microservice-chart:
         metadata:
           type: Utilization
           value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
 
   envConfig:
     MONGODB_DBNAME: mdc

--- a/helm/uat/top/emd-ar-backoffice-bff/values.yaml
+++ b/helm/uat/top/emd-ar-backoffice-bff/values.yaml
@@ -21,4 +21,15 @@ microservice-chart:
   autoscaling:
     enable: true
     minReplica: 2
-    maxReplica: 3
+    maxReplica: 4
+    pollingInterval: 30 # seconds
+    cooldownPeriod: 300 # seconds
+    triggers:
+      - type: cpu
+        metadata:
+          type: Utilization
+          value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1

--- a/helm/uat/top/emd-citizen/values.yaml
+++ b/helm/uat/top/emd-citizen/values.yaml
@@ -17,8 +17,8 @@ microservice-chart:
 
   autoscaling:
     enable: true
-    minReplica: 1
-    maxReplica: 2
+    minReplica: 2
+    maxReplica: 4
     pollingInterval: 30 # seconds
     cooldownPeriod: 300 # seconds
     triggers:
@@ -26,6 +26,10 @@ microservice-chart:
         metadata:
           type: Utilization
           value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
 
   envConfig:
     MONGODB_DBNAME: mdc

--- a/helm/uat/top/emd-message-core/values.yaml
+++ b/helm/uat/top/emd-message-core/values.yaml
@@ -17,8 +17,8 @@ microservice-chart:
 
   autoscaling:
     enable: true
-    minReplica: 1
-    maxReplica: 2
+    minReplica: 2
+    maxReplica: 4
     pollingInterval: 30 # seconds
     cooldownPeriod: 300 # seconds
     triggers:
@@ -26,6 +26,10 @@ microservice-chart:
         metadata:
           type: Utilization
           value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
 
   envConfig:
     MONGODB_DBNAME: mdc

--- a/helm/uat/top/emd-notifier-sender/values.yaml
+++ b/helm/uat/top/emd-notifier-sender/values.yaml
@@ -17,8 +17,8 @@ microservice-chart:
 
   autoscaling:
     enable: true
-    minReplica: 1
-    maxReplica: 2
+    minReplica: 2
+    maxReplica: 4
     pollingInterval: 30 # seconds
     cooldownPeriod: 300 # seconds
     triggers:
@@ -26,6 +26,10 @@ microservice-chart:
         metadata:
           type: Utilization
           value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
 
   envSecret:
     MY_KV_SECRET: cstar-u-itn-uat-aks-apiserver-url

--- a/helm/uat/top/emd-payment-core/values.yaml
+++ b/helm/uat/top/emd-payment-core/values.yaml
@@ -17,8 +17,8 @@ microservice-chart:
 
   autoscaling:
     enable: true
-    minReplica: 1
-    maxReplica: 2
+    minReplica: 2
+    maxReplica: 4
     pollingInterval: 30 # seconds
     cooldownPeriod: 300 # seconds
     triggers:
@@ -26,6 +26,10 @@ microservice-chart:
         metadata:
           type: Utilization
           value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
 
   envConfig:
     MONGODB_DBNAME: mdc

--- a/helm/uat/top/emd-tpp/values.yaml
+++ b/helm/uat/top/emd-tpp/values.yaml
@@ -17,8 +17,8 @@ microservice-chart:
 
   autoscaling:
     enable: true
-    minReplica: 1
-    maxReplica: 2
+    minReplica: 2
+    maxReplica: 4
     pollingInterval: 30 # seconds
     cooldownPeriod: 300 # seconds
     triggers:
@@ -26,6 +26,10 @@ microservice-chart:
         metadata:
           type: Utilization
           value: "60"
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
 
   envConfig:
     MONGODB_DBNAME: mdc


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

In UAT e PROD:
- Autoscaling: min: 2, max: 4. (Garantisce ridondanza minima e gestione dei picchi di traffico).
- PDB: create: true, maxUnavailable: 1. (Impedisce downtime durante la manutenzione del cluster, assicurando che non venga mai spenta più di una replica alla volta).

### Motivation and context

L'autoscaling (2-4 repliche) gestisce i carichi di traffico variabili, mentre il maxUnavailable: 1 garantisce che il servizio rimanga sempre online durante le operazioni di manutenzione del cluster (come gli upgrade di Azure), assicurando che non venga mai spenta più di una replica alla volta.

### Type of changes

- [x] Add new feature
- [ ] Update existing feature
- [ ] Remove existing feature
- [ ] Other changes

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
